### PR TITLE
Validate numeric values in the Settings model.

### DIFF
--- a/models/Settings.php
+++ b/models/Settings.php
@@ -10,11 +10,24 @@ class Settings extends Model
 
     use \October\Rain\Database\Traits\Validation;
     public $rules = [
-        'digits'                => 'required_if:is_enabled,1,true',
+        'digits' => 'required_if:is_enabled,1,true|numeric',
     ];
     // A unique code
     public $settingsCode = 'vannut_wipprotect_settings';
 
     // Reference to field configuration
     public $settingsFields = 'fields.yaml';
+
+    public function afterValidate()
+    {
+        $postData = post('Settings');
+
+        if (!$postData['is_enabled']) {
+            return true;
+        }
+
+        if (!is_numeric($postData['digits'])) {
+            throw new \ValidationException(['digits' => 'The authorization code must only contain numbers (no letters or special characters).']);
+        }
+    }
 }


### PR DESCRIPTION
A simple addition that displays an error message to the user when non numeric values are sent in the Settings form for the authorization code.