### PR TITLE
Disable test routes found in the routes.php file

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -1,11 +1,11 @@
 <?php
 
-Route::get('/set', function () {
-    Session::keep('vannut_wipprotect', true);
+// Route::get('/set', function () {
+//     Session::keep('vannut_wipprotect', true);
 
-    return Session::all();
-});
+//     return Session::all();
+// });
 
-Route::get('/test', function () {
-    return 'test-route';
-});
+// Route::get('/test', function () {
+//     return 'test-route';
+// });


### PR DESCRIPTION
These could be dangerous as they seem to be returning session data and could override existing routes in the CMS.